### PR TITLE
fix: Remove Cyclic dependency from cli-add-command-plugin

### DIFF
--- a/cli-add-command-plugin/plugin.yaml
+++ b/cli-add-command-plugin/plugin.yaml
@@ -14,7 +14,7 @@ technologies: # Ref: https://docs.stackspot.com/latest/docs/creators-guide/yaml/
 types:
   - app
 requirements:
-  - stackspot-python-stack/cli-add-command-plugin
+  - stackspot-python-stack/cli-plugin
 inputs:
   - label: command
     type: text


### PR DESCRIPTION
Descrição:

Removendo dependência cíclica do plugin de adicionar comando